### PR TITLE
Claudeのインストール経路をnpmに統一し、effortをxhighに変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,6 @@ BREW_PACKAGES = \
 	google-drive \
 	slack \
 	daisydisk \
-	claude \
-	claude-code \
 	uv \
 	coreutils \
 	fd \

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -24,7 +24,7 @@ alias vi="nvim"
 alias python="python3"
 alias pip="pip3"
 alias ggr='git log --graph --date-order -C -M --pretty=format:"<%h> %ad [%an] %Cgreen%d%Creset %s" --all --date=short'
-alias claude="claude --effort max"
+alias claude="claude --effort xhigh"
 
 setopt noflowcontrol
 bindkey "^s" history-incremental-search-forward


### PR DESCRIPTION
## Summary
- claudeのインストール経路をbrew(`claude`/`claude-code`)からnpm(`@anthropic-ai/claude-code`)に一本化
- claude aliasのeffortを `max` から `xhigh` に変更

## Test plan
- [ ] `make install` 実行時にbrew経由のclaudeがインストールされないことを確認
- [ ] zshを再読み込み後、`alias claude` で `--effort xhigh` になっていることを確認