### PR TITLE
Claude CodeとawsumeをAWS credential_process経由で連携する

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -24,7 +24,24 @@ alias vi="nvim"
 alias python="python3"
 alias pip="pip3"
 alias ggr='git log --graph --date-order -C -M --pretty=format:"<%h> %ad [%an] %Cgreen%d%Creset %s" --all --date=short'
-alias claude="claude --effort xhigh"
+# Claude Code は credential_process 経由で ~/.aws-session/current を読む
+# 親シェルから export された AWS_* 環境変数は子プロセスに渡さず、AWS_PROFILE を優先させる
+alias claude='env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u AWS_SECURITY_TOKEN AWS_PROFILE=claude-aws-session claude --effort xhigh'
+
+# Claude Code 起動前に ~/.aws-session/current を更新するブートストラップ
+# (Claude Code 内の /awsume-save スキルと等価。最初に Claude Code を起動する際に必要)
+awsume-save-for-claude() {
+  if [[ $# -eq 0 ]]; then
+    echo "usage: awsume-save-for-claude <profile>" >&2
+    return 1
+  fi
+  awsume "$1" || return $?
+  mkdir -p ~/.aws-session
+  env | grep -E '^(AWS_|AWSUME_)' > ~/.aws-session/current
+  echo "AWS_SESSION_SAVED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> ~/.aws-session/current
+  echo "AWSUME_PROFILE=$1" >> ~/.aws-session/current
+  echo "saved credentials for profile=$1 to ~/.aws-session/current"
+}
 
 setopt noflowcontrol
 bindkey "^s" history-incremental-search-forward


### PR DESCRIPTION
## Summary

- Claude Code 起動時に親シェルへ awsume export されている `AWS_*` を `env -u` で剥がし、`AWS_PROFILE=claude-aws-session`
を子プロセスへ渡すよう `alias claude` を更新
- 初回 Claude Code 起動前に `~/.aws-session/current` を populate するためのシェル関数 `awsume-save-for-claude` を追加
- 既存の `--effort xhigh` は維持

## Why

`plugin:aws-core:aws-mcp` の `mcp-proxy-for-aws` は upstream HTTP リクエストをすべて SigV4 署名するため、initialize 時点で AWS credentials が解決できないと `NoCredentialsError` で MCP server が起動できない。

親シェルに export された `AWS_*` を子プロセスへ継承させると STS トークン期限切れのたびに Claude Code
を再起動する必要がある。`~/.aws/config` の `claude-aws-session` プロファイルで `credential_process =
~/.aws-session/credential_process.sh` を指定し、Claude Code には `AWS_PROFILE` のみを渡すことで、Claude Code を起動したまま`/awsume-save <profile>` で credentials を更新できるようになる。

`env -u` で `AWS_*` を剥がしているのは、これらの環境変数が `AWS_PROFILE` より優先されてしまうため。

## Related changes (このリポジトリ外)

セットアップ手順は別途以下が必要:

- `~/.aws-session/credential_process.sh` を作成（実行権限付与）
- `~/.aws/config` に `[profile claude-aws-session]` を追記
- 詳細は claude-doc-context リポジトリの公開ドキュメントを参照

## Test plan

- [ ] `~/.zshrc` を再読込（`exec zsh`）
- [ ] `awsume-save-for-claude <profile>` を実行 → `~/.aws-session/current` が更新されること
- [ ] `claude` を起動 → `/mcp` で `plugin:aws-core:aws-mcp` が `connected` になること
- [ ] Claude Code 起動中に別 terminal で `~/.aws-session/current` を更新 → Claude Code 内の `call_aws` ツールから新 credentialsで実行できること